### PR TITLE
[v13] enable installation in TYPO3 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "issues": "https://github.com/sitegeist/csv-labels/issues"
     },
     "require": {
-        "typo3/cms-core": "^12.2 || ^11.5 || ^10.4 || ^9.5"
+        "typo3/cms-core": "^13.1 || ^12.2 || ^11.5 || ^10.4 || ^9.5"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.0",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,7 +12,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '',
     'constraints' => [
         'depends' => [
-            'typo3' => '9.5.0-12.9.99',
+            'typo3' => '9.5.0-13.9.99',
             'php' => '7.4.0-8.9.99'
         ],
         'conflicts' => [


### PR DESCRIPTION
* extension scanner is still happy
* registration of language parser is still straight forward in $GLOBALS['TYPO3_CONF_VARS']